### PR TITLE
Give priority to target module hints when stringifying imports

### DIFF
--- a/elm/Indexer.elm
+++ b/elm/Indexer.elm
@@ -1306,7 +1306,10 @@ importsToString imports tokens =
                                     token
 
                             hints =
+                                -- Get all hints with all hints from target module in the front of the List
                                 getHintsForToken (Just token) tokens
+                                    |> List.partition (.moduleName >> (==) moduleName)
+                                    |> uncurry (++)
                         in
                             case List.head hints of
                                 Just { caseTipe } ->


### PR DESCRIPTION
Will solve #41.

The bug was introduced by using the first `Hint`, but it may be the case that the first hint is not a hint from the target module. Solved this by partitioning the list and then concatenating it again. I believe that this will fix it (modules cannot declare a certain type/type alias twice and thus the first `Hint` will be the correct import reference.

One thing I do not understand is why this code relies on `Hint`s? This makes it prone to these kind of errors. What is the use case for this?

Should I also generate the new `indexer.js`?