### PR TITLE
Fixes #107 Verify filePath is a file in sendFileContentsChanged

### DIFF
--- a/lib/indexing.js
+++ b/lib/indexing.js
@@ -12,6 +12,9 @@ export default {
     if (!projectDirectory) {
       return;
     }
+    if (!fs.statSync(filePath).isFile()) {
+      return
+    }
     const text = fs.readFileSync(filePath).toString();
     indexer.fileContentsChanged([
       filePath,


### PR DESCRIPTION
The error in #107 was triggered because my project has a symlink to a folder. It looks like the symlink gets picked up by the watcher, but because it points to a folder it isn't compatible with `fs.readFileSync`.

https://github.com/halohalospecial/atom-elmjutsu/blob/33d6ccce89057e5cd4f648f268b30cd6c9c8c313/lib/core.js#L363-L378