### PR TITLE
Make text within data hint inlined with styleguide

### DIFF
--- a/lib/datatip-view.js
+++ b/lib/datatip-view.js
@@ -113,14 +113,14 @@ export default {
             return (
               <div className="datatip-marked-container">
                 <div className="elmjutsu-datatip">
-                  <h4 key={i}>
+                  <div className="elmjutsu-datatip-header" key={i}>
                     {maybeModuleName}
                     <strong>{maybeName}</strong>
                     <em>{maybeArgs}</em>
                     {maybeTipeView}
                     {maybeTypeCasesView}
                     {maybeAliasesOfTypeView}
-                  </h4>
+                  </div>
                   <div
                     className="comment"
                     dangerouslySetInnerHTML={{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elmjutsu",
-  "version": "7.2.2",
+  "version": "7.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/styles/elmjutsu.less
+++ b/styles/elmjutsu.less
@@ -188,6 +188,12 @@ atom-text-editor.elmjutsu-pipe-selections.processing {
   .comment {
     margin: 15px 0;
   }
+  .elmjutsu-datatip-header {
+    font-size: @font-size;
+    strong {
+      color: @syntax-color-class
+    }
+  }
 }
 .elmjutsu-sidekick {
   .elmjutsu-hint-view;
@@ -247,6 +253,7 @@ atom-text-editor:not([mini])[data-grammar='source elm']
   max-width: 700px;
 }
 .elmjutsu-token-actionable {
+  color: @syntax-color-attribute;
   &:hover {
     background-color: rgba(0, 0, 0, 0.3);
     cursor: pointer;


### PR DESCRIPTION
I'm proposing slightly more compact styles for data hints:

<img width="822" alt="screen shot 2018-04-10 at 19 17 56" src="https://user-images.githubusercontent.com/1846484/38548044-1d091f54-3cf4-11e8-9e03-e62e1bd9bf4e.png">
