### PR TITLE
Add option for running Elm executable(s) local to project directory

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -311,6 +311,14 @@ export default {
     order: 45,
   },
 
+  useNodeModulesBin: {
+    title: 'Prepend Project\'s node_modules/bin To Path',
+    description: 'If you prefer to install the Elm compiler locally (in the project directory) rather than system-wide, turn on this option to look for the Elm executable(s) in your project\'s `node_modules/bin` folder first.',
+    type: 'boolean',
+    default: false,
+    order: 45.5
+  },
+
   elmExecPath: {
     title: 'Elm Path',
     description: 'Path to the `elm` executable.',

--- a/lib/elm-make-runner.js
+++ b/lib/elm-make-runner.js
@@ -53,6 +53,10 @@ export default class ElmMakeRunner {
       atom.config.get('elmjutsu.alwaysCompileMain') === true;
     const editorFilePath = editor.getPath();
     const projectDirectory = helper.getProjectDirectory(editorFilePath);
+    const localExecOption =
+      atom.config.get('elmjutsu.useNodeModulesBin') === true
+        ? { directory: projectDirectory, prepend: true }
+        : undefined;
 
     let filePathsToCompile = [editorFilePath];
     if (alwaysCompileMain) {
@@ -75,7 +79,7 @@ export default class ElmMakeRunner {
         uniqueKey: 'elm make: ' + projectDirectory,
         stream: 'both', // stdout and stderr
         cwd: projectDirectory,
-        // env: process.env,
+        local: localExecOption
       })
       .then(data => {
         // console.log('data', data);


### PR DESCRIPTION
What is the change?: Add a config option to prepend \<project directory\>/node_modules/bin to the PATH when running the Elm executable(s). The `options.local` object is defined in the [sb-exec readme](https://github.com/steelbrain/exec#optionslocal).

Why did I do this?: To support a "virtual environment" style of Elm projects. I like to install language compilers in a local sandbox rather than use a system-wide binary. This means I can, for example, use different versions of a language in different projects.