### PR TITLE
Show the raw stderr when compile fails & it cannot be parsed as JSON

### DIFF
--- a/lib/elm-make-runner.js
+++ b/lib/elm-make-runner.js
@@ -137,8 +137,7 @@ export default class ElmMakeRunner {
               result = JSON.parse(data.stderr);
             } catch (e) {
               atom.notifications.addError('Compile error', {
-                detail:
-                  'Error parsing output. Please check the value of `Elm Path` and/or `Elm Test Path` in the Settings view.',
+                detail: `Error parsing output:\n${data.stderr}`,
                 dismissable: true,
               });
               return resolve(null);


### PR DESCRIPTION
When the compile fails and the `stderr` cannot be parsed as JSON, the raw `stderr` is much more useful than a generic error message, for example:

![](https://user-images.githubusercontent.com/2421069/48551915-c7ee7280-e8ce-11e8-9d77-ea5105d193b6.PNG)

This PR changes the error message to include the raw `stderr` output.