### PR TITLE
[#131] Pass relative paths to elm-test in win32

### DIFF
--- a/lib/elm-make-runner.js
+++ b/lib/elm-make-runner.js
@@ -88,7 +88,13 @@ export default class ElmMakeRunner {
         }
       }
     } else {
-      filePathsToCompile = [editorFilePath];
+      if (isTestFilePath && process.platform === 'win32') {
+        // Workaround for https://github.com/halohalospecial/atom-elmjutsu/issues/131#issuecomment-429445645
+        const relativeEditorFilePath = path.relative(projectDirectory, editorFilePath);
+        filePathsToCompile = [relativeEditorFilePath];
+      } else {
+        filePathsToCompile = [editorFilePath];
+      }
     }
 
     const outputPath = '/dev/null'; // TODO: Make this configurable (elmjutsu-config.json).


### PR DESCRIPTION
https://github.com/halohalospecial/atom-elmjutsu/issues/131#issuecomment-435842031

How to test:
- In Windows Atom, open some Elm project's file in `tests/` directory
- Set "Always compile main" disabled
- Trigger compile

Before this patch:
- should fail with "What should I make though?" compiler error

With this patch:
- should compile the file