### PR TITLE
update readme with recommended linter version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://atom.io/packages/elmjutsu
 * Install [Elm](http://elm-lang.org/install).
 * Install [language-elm](https://atom.io/packages/language-elm) (no need to install `elm-oracle` or `goto`).
 * For `Error Highlighting`:
-  * Install [atom-ide-ui](https://atom.io/packages/atom-ide-ui) or [linter](https://atom.io/packages/linter) + [linter-ui-default](https://atom.io/packages/linter-ui-default).
+  * Install [atom-ide-ui](https://atom.io/packages/atom-ide-ui) or [linter@1.11.23](https://atom.io/packages/linter) + [linter-ui-default](https://atom.io/packages/linter-ui-default).
 * For `Go to Definition`:
   * Install [atom-ide-ui](https://atom.io/packages/atom-ide-ui) or [hyperclick](https://atom.io/packages/hyperclick) (both optional).
 * For `Autocomplete`:


### PR DESCRIPTION
I wasn't able to get any error highlighting with this package until I ran `apm install linter@1.11.23`. I think to update to the current version of the linter package, the provideLinter function in [main.js](https://github.com/halohalospecial/atom-elmjutsu/blob/master/lib/main.js#L301) would have to update to this [new API](https://github.com/steelbrain/linter/blob/1f9efea649c43ab50097d6ddc0d1e9685ee28413/docs/guides/upgrading-to-standard-linter-v2.md). I haven't looked at it very closely, but for the time being I think this is a helpful recommendation for new users.